### PR TITLE
Fix Reddit custom feed url format

### DIFF
--- a/src/lib/model/sources/reddit/customFeed.ts
+++ b/src/lib/model/sources/reddit/customFeed.ts
@@ -8,7 +8,7 @@ export class RedditCustomFeedSource implements Source<string, RedditResponse> {
 
     constructor(user: string, feed: string) {
         this.name = `r/${user}/${feed}`;
-        this.baseUrl = new URL(`https://www.reddit.com/u/${user}/m/${feed}.json`);
+        this.baseUrl = new URL(`https://www.reddit.com/user/${user}/m/${feed}/new.json`);
     }
 
     getPageUrl(pageId: string): URL {


### PR DESCRIPTION
Previous format would trigger a redirect to the updated one, and is blocked by CORS.

Fixes #29 