### PR TITLE
Prevent further fetching for exhausted feeds

### DIFF
--- a/src/lib/components/ImageGallery.svelte
+++ b/src/lib/components/ImageGallery.svelte
@@ -34,6 +34,8 @@
     const sourceStream = new SourceStream(imageSource);
     const imageFeed = new ImageFeed(sourceStream);
 
+    const feedExhausted = imageFeed.exhausted;
+
     let selectedImageIndex: number | null = null;
     $: selectedImage =
         selectedImageIndex !== null ? $imageFeed[selectedImageIndex] : null;
@@ -46,10 +48,13 @@
         do {
             console.log("Trying to fetch");
 
-            if (!imageFeed.exhausted) {
-                console.log("Fetching");
-                await imageFeed.requestFetch();
+            if ($feedExhausted) {
+                console.log("Feed exhausted");
+                break;
             }
+
+            console.log("Fetching");
+            await imageFeed.requestFetch();
 
             console.log("Done fetching");
         } while (!screenIsFilled);
@@ -114,17 +119,19 @@
         on:select={(e) => openLightbox(e.detail)}
     />
 
-    <IntersectionObserver
-        on:enter={tryFetch}
-        on:exit|once={() => (screenIsFilled = true)}
-    >
-        <img
-            class="loading"
-            alt="Loading indicator"
-            src="/loading.svg"
-            width="50px"
-        />
-    </IntersectionObserver>
+    {#if !$feedExhausted}
+        <IntersectionObserver
+            on:enter={tryFetch}
+            on:exit|once={() => (screenIsFilled = true)}
+        >
+            <img
+                class="loading"
+                alt="Loading indicator"
+                src="/loading.svg"
+                width="50px"
+            />
+        </IntersectionObserver>
+    {/if}
 </main>
 
 <style>

--- a/src/lib/model/ImageFeed.ts
+++ b/src/lib/model/ImageFeed.ts
@@ -1,5 +1,10 @@
 import { tick } from "svelte";
-import { writable, Unsubscriber, Writable } from "svelte/store";
+import {
+    writable,
+    Unsubscriber,
+    Writable,
+    Readable,
+} from "svelte/store";
 import { prefetchDimensions } from "../util/prefetchDimensions";
 import { TaskQueue } from "../util/TaskQueue";
 import { SourceStream, InternalImage } from "./ImageSource";
@@ -13,7 +18,8 @@ export type AnnotatedImage = {
 };
 
 export class ImageFeed {
-    exhausted: boolean = false;
+    private _exhausted: Writable<boolean> = writable(false);
+    readonly exhausted: Readable<boolean> = { subscribe: this._exhausted.subscribe };
 
     private isFetching: boolean = false;
 
@@ -57,7 +63,7 @@ export class ImageFeed {
         const moreImagesFiltered = await this.source.fetchNextPage();
 
         if (moreImagesFiltered.length === 0) {
-            this.exhausted = true;
+            this._exhausted.set(true);
             return;
         }
 


### PR DESCRIPTION
If a feed is exhausted before the initial fill loop completes, we break out of it to avoid looping infinitely. We also hide the IntersectionObserver/loading indicator to prevent further fetch attempts and signal to the user that the feed is fully loaded.

Closes #71 